### PR TITLE
Config allows the use as NTP client with no config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ ntp_servers:
 ntp_peers: []
 
 # allow access from these subnets
+net_allow: []
 # net_allow:
 #   - '192.168.0.0/16'
 


### PR DESCRIPTION
Empty net_allow, add cidrs for sharing.